### PR TITLE
Maven Turbo Builder (with Develocity extension)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build
 .DS_Store
 *.versionsBackup
 .m2
+.mvn/.develocity

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,11 @@
+<develocity>
+    <buildScan>
+        <publishing>
+            <onlyIf>true</onlyIf>
+        </publishing>
+        <termsOfUse>
+            <url>https://gradle.com/help/legal-terms-of-use</url>
+            <accept>true</accept>
+        </termsOfUse>
+    </buildScan>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,18 @@
+<extensions>
+  <extension>
+    <!--
+    Used for timeline visualization
+    Disable caching: "-Ddevelocity.cache.local.enabled=false"
+    -->
+    <groupId>com.gradle</groupId>
+    <artifactId>develocity-maven-extension</artifactId>
+    <version>2.4.0</version>
+  </extension>
+
+  <extension>
+    <!-- https://github.com/maven-turbo-reactor/maven-turbo-builder -->
+    <groupId>com.github.seregamorph</groupId>
+    <artifactId>maven-turbo-builder</artifactId>
+    <version>1.1</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-T1C
+-bturbo


### PR DESCRIPTION
Example usage of https://github.com/seregamorph/maven-turbo-reactor in combination with Develocity, the extension to boost standard Maven Reactor. See detailed [project readme](https://github.com/seregamorph/maven-turbo-reactor/blob/master/README.md) and [presentation board](https://miro.com/app/board/uXjVLYUPRas=/).

Checkout the branch and compare the build with standard reactor and with Turbo builder.

Standard reactor:
```shell
mvn clean verify -T8 -Ddevelocity.cache.local.enabled=false
```
The build takes around `3m5s`. Build scan: https://scans.gradle.com/s/3frso2gomfi6e
Note, that build caching is **intentionally disabled** to highlight the behavior of the extension for the worst case (the caching is supported). 

Now try with Turbo builder:
```shell
mvn clean verify -T8 -Ddevelocity.cache.local.enabled=false -b turbo
```
The build takes `2m21s`!. Build scan: https://scans.gradle.com/s/cuw4ij64chf5i

Now you can try with enabled build cache (enabled by default):
```
mvn clean verify -T8
```
The build takes just `21s`. Build scan: https://scans.gradle.com/s/gwvkv2brrtxfc
The Turbo reactor is compatible with Develocity extension.