### PR TITLE
Maven Turbo Builder (with Surefire Cached extension)

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,18 @@
+<extensions>
+  <extension>
+    <!--
+    https://github.com/seregamorph/maven-surefire-cached
+    Disable caching: "-DskipCache=true"
+    -->
+    <groupId>com.github.seregamorph</groupId>
+    <artifactId>surefire-cached-extension</artifactId>
+    <version>0.29</version>
+  </extension>
+
+  <extension>
+    <!-- https://github.com/maven-turbo-reactor/maven-turbo-builder -->
+    <groupId>com.github.seregamorph</groupId>
+    <artifactId>maven-turbo-builder</artifactId>
+    <version>1.1</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-T1C
+-bturbo


### PR DESCRIPTION
Example usage of https://github.com/seregamorph/maven-turbo-reactor in combination with [maven-surefire-cached extension](https://github.com/seregamorph/maven-surefire-cached), the extension to boost standard Maven Reactor. See detailed [project readme](https://github.com/seregamorph/maven-turbo-reactor/blob/master/README.md) and [presentation board](https://miro.com/app/board/uXjVLYUPRas=/).

Checkout the branch and compare the build with standard reactor and with Turbo builder.

Standard reactor:
```shell
mvn clean verify -T8 -DskipCache=true
```
The build takes around `2m56s`.
Note, that build caching is **intentionally disabled** to highlight the behavior of the extension for the worst case (the caching is supported). 

Now try with Turbo builder:
```shell
mvn clean verify -T8 -DskipCache=true -b turbo
```
The build takes `2m21s`!.

Now you can try with enabled build cache (enabled by default), run at least twice:
```
mvn clean verify -T8
```
The build takes just `21s`.
The Turbo reactor is compatible with maven surefire cached extension.